### PR TITLE
Loading the filter works now

### DIFF
--- a/src/components/BoardFilters/FilterConfigModal.ts
+++ b/src/components/BoardFilters/FilterConfigModal.ts
@@ -301,7 +301,7 @@ export class FilterConfigModal extends Modal {
 			}
 
 			// Update the board filter state
-			board.boardFilter = config.filterState;
+			board.boardFilter = JSON.parse(JSON.stringify(config.filterState));
 			await this.plugin.saveSettings();
 
 			new Notice(

--- a/src/components/BoardFilters/ViewTaskFilter.ts
+++ b/src/components/BoardFilters/ViewTaskFilter.ts
@@ -235,7 +235,7 @@ export class TaskFilterComponent extends Component {
 						}
 					);
 
-					this.registerDomEvent(el, "click", () => {
+					this.registerDomEvent(el, "click", async () => {
 						this.openSaveConfigModal();
 					});
 				}
@@ -259,7 +259,7 @@ export class TaskFilterComponent extends Component {
 						}
 					);
 
-					this.registerDomEvent(el, "click", () => {
+					this.registerDomEvent(el, "click", async () => {
 						this.openLoadConfigModal();
 					});
 				}
@@ -1354,13 +1354,7 @@ export class TaskFilterComponent extends Component {
 			this.plugin,
 			"save",
 			this.activeBoardIndex,
-			this.getFilterState(),
-			(config: SavedFilterConfig) => {
-				// Optional: Handle successful save
-				new Notice(
-					`${t("filter-configs-saved-successfully")} : ${config.name}`
-				);
-			}
+			this.getFilterState()
 		);
 		modal.open();
 	}
@@ -1372,18 +1366,7 @@ export class TaskFilterComponent extends Component {
 			this.app,
 			this.plugin,
 			"load",
-			this.activeBoardIndex,
-			undefined,
-			undefined,
-			(config: SavedFilterConfig) => {
-				// Load the configuration
-				this.loadFilterState(config.filterState);
-				new Notice(
-					`${t("filter-configuration-loaded-successfully")} : ${
-						config.name
-					}`
-				);
-			}
+			this.activeBoardIndex
 		);
 		modal.open();
 	}


### PR DESCRIPTION
### **User description**
It fixes #547

However, it seems that the entire save/load feature was hastily added to the existing filtering functionality some time ago. The fix is in this spirit. It works, but the loading and saving should be redesigned.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove callback-based architecture from filter save/load

- Move filter state management directly into modal

- Automatically apply loaded filters and persist to settings

- Improve user feedback with config names in notices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Filter Config Modal"] -->|"Remove callbacks"| B["Direct State Management"]
  B -->|"Save filter"| C["Update Board Settings"]
  B -->|"Load filter"| D["Apply to Board Filter"]
  D -->|"Persist"| C
  E["Task Filter Component"] -->|"Simplified calls"| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FilterConfigModal.ts</strong><dd><code>Refactor callbacks to direct state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/BoardFilters/FilterConfigModal.ts

<ul><li>Remove <code>onSave</code> and <code>onLoad</code> callback parameters from constructor<br> <li> Implement direct filter state application in load method<br> <li> Initialize board filter if missing before applying loaded config<br> <li> Enhance user notices to include config names<br> <li> Simplify modal reopening by removing callback parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/tu2-atmanand/Task-Board/pull/549/files#diff-fcceb05f18242ca8ce8bd37379e7abbdc9652140d182d8ca9028f73968d1239f">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ViewTaskFilter.ts</strong><dd><code>Simplify modal calls and remove callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/BoardFilters/ViewTaskFilter.ts

<ul><li>Remove callback handlers from save and load modal instantiation<br> <li> Simplify modal opening methods by eliminating callback logic<br> <li> Mark click handlers as async for consistency<br> <li> Move filter state application responsibility to modal</ul>


</details>


  </td>
  <td><a href="https://github.com/tu2-atmanand/Task-Board/pull/549/files#diff-880cd596f511e26971f53dacfe8206a7612e7343eee802dc83b7d3f25ebc7bbc">+4/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

