### PR TITLE
Elegant solution for broken filters

### DIFF
--- a/src/components/BoardFilters/FilterConfigModal.ts
+++ b/src/components/BoardFilters/FilterConfigModal.ts
@@ -268,8 +268,6 @@ export class FilterConfigModal extends Modal {
 			board.filterConfig.savedConfigs.push(config);
 			await this.plugin.saveSettings();
 
-			new Notice(t("filter-configs-saved-successfully"));
-
 			if (this.onSave) {
 				this.onSave(config);
 			}
@@ -305,7 +303,6 @@ export class FilterConfigModal extends Modal {
 				this.onLoad(config);
 			}
 
-			new Notice(t("filter-configuration-loaded-successfully"));
 			this.close();
 		} catch (error) {
 			console.error("Failed to load filter configuration:", error);

--- a/src/components/BoardFilters/ViewTaskFilter.ts
+++ b/src/components/BoardFilters/ViewTaskFilter.ts
@@ -44,6 +44,7 @@ export class TaskFilterComponent extends Component {
 		MultiSuggest
 	>();
 	public isMultiSuggestDropdownActive = false;
+	public isConfigModalOpen = false;
 
 	constructor(
 		hostEl: HTMLElement,
@@ -235,7 +236,7 @@ export class TaskFilterComponent extends Component {
 						}
 					);
 
-					this.registerDomEvent(el, "click", () => {
+					this.registerDomEvent(el, "click", async () => {
 						this.openSaveConfigModal();
 					});
 				}
@@ -259,7 +260,7 @@ export class TaskFilterComponent extends Component {
 						}
 					);
 
-					this.registerDomEvent(el, "click", () => {
+					this.registerDomEvent(el, "click", async () => {
 						this.openLoadConfigModal();
 					});
 				}
@@ -1362,6 +1363,10 @@ export class TaskFilterComponent extends Component {
 				);
 			}
 		);
+		modal.setCloseCallback(() => {
+			this.isConfigModalOpen = false;
+		});
+		this.isConfigModalOpen = true;
 		modal.open();
 	}
 
@@ -1385,6 +1390,10 @@ export class TaskFilterComponent extends Component {
 				);
 			}
 		);
+		modal.setCloseCallback(() => {
+			this.isConfigModalOpen = false;
+		});
+		this.isConfigModalOpen = true;
 		modal.open();
 	}
 }

--- a/src/components/BoardFilters/ViewTaskFilterPopover.ts
+++ b/src/components/BoardFilters/ViewTaskFilterPopover.ts
@@ -176,6 +176,7 @@ export class ViewTaskFilterPopover
 
 		if (
 			!this.taskFilterComponent.isMultiSuggestDropdownActive &&
+			!this.taskFilterComponent.isConfigModalOpen &&
 			this.popoverRef &&
 			!this.popoverRef.contains(e.target as Node)
 		) {


### PR DESCRIPTION
### **User description**
This is a proper fix for #547 

The real problem was that the `ViewTaskFilter` component, which is a member of `ViewTaskFilterPopover`, opens the `FilterConfigModal`. Clicking anywhere inside the latter closes the former, which then "unloads". The config modal ends up holding references to a "dead" object (`ViewTaskFilter`).

I also removed the doubled loading/saving Notice messages.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes filter modal closing popover by tracking modal state

- Prevents popover from closing when config modal is open

- Removes duplicate success notices from modal operations

- Adds close callback to properly manage modal state lifecycle


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ViewTaskFilterPopover"] -->|checks isConfigModalOpen| B["clickOutside handler"]
  C["FilterConfigModal"] -->|removed duplicate notices| D["Cleaner UX"]
  E["TaskFilterComponent"] -->|tracks modal state| F["setCloseCallback"]
  F -->|updates isConfigModalOpen| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewTaskFilterPopover.ts</strong><dd><code>Prevent popover close during config modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/BoardFilters/ViewTaskFilterPopover.ts

<ul><li>Added check for <code>isConfigModalOpen</code> flag in <code>clickOutside</code> handler<br> <li> Prevents popover from closing when config modal is active<br> <li> Allows modal to remain open without triggering popover closure</ul>


</details>


  </td>
  <td><a href="https://github.com/tu2-atmanand/Task-Board/pull/552/files#diff-749f68c8fc0456ce6137ce1fe6e76fd48e78c3fc898bcb3ebe49d55034cfe8ee">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ViewTaskFilter.ts</strong><dd><code>Track config modal state and manage callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/BoardFilters/ViewTaskFilter.ts

<ul><li>Added <code>isConfigModalOpen</code> boolean flag to track modal state<br> <li> Implemented <code>setCloseCallback</code> to update flag when modal closes<br> <li> Set flag to true when opening save/load config modals<br> <li> Moved success notices from modal to component level<br> <li> Made click handlers async for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/tu2-atmanand/Task-Board/pull/552/files#diff-880cd596f511e26971f53dacfe8206a7612e7343eee802dc83b7d3f25ebc7bbc">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FilterConfigModal.ts</strong><dd><code>Remove duplicate success notification messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/BoardFilters/FilterConfigModal.ts

<ul><li>Removed duplicate "filter-configs-saved-successfully" notice<br> <li> Removed duplicate "filter-configuration-loaded-successfully" notice<br> <li> Notices now handled by parent component instead</ul>


</details>


  </td>
  <td><a href="https://github.com/tu2-atmanand/Task-Board/pull/552/files#diff-fcceb05f18242ca8ce8bd37379e7abbdc9652140d182d8ca9028f73968d1239f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

