### PR TITLE
Update links in README for documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Join the forum top to share your thoughts, ideas or requests and hear from other
 
 ## How to start ?
 
-**Step 1 :** Install and Enable the plugin : [How to install Task Board](https://tu2-atmanand.github.io/task-board-docs/docs/Installation/).
+**Step 1 :** Install and Enable the plugin : [How to install Task Board](https://tu2-atmanand.github.io/task-board-docs/docs/3_Installation/).
 
 **Step 2 :** Open Task Board using the Icon from the right side Ribbon Icon Bar. There is also a command in the Command Pallet.
 
-**Step 3 :** Click on the **Scan vault modal** button from the top-right corner in the Task Board view header. Then click on the run button and it will scan all your files to look for tasks. If your vault contains thousands of notes, you can apply [scanning filters](https://tu2-atmanand.github.io/task-board-docs/docs/Features/Filters_for_Scanning/) to exclude certain files from scanning.
+**Step 3 :** Click on the **Scan vault modal** button from the top-right corner in the Task Board view header. Then click on the run button and it will scan all your files to look for tasks. If your vault contains thousands of notes, you can apply [scanning filters](https://tu2-atmanand.github.io/task-board-docs/docs/6_Features/10_Filters_for_Scanning/) to exclude certain files from scanning.
 
-**Step 4 :** There are already three predefined board for your convenience as an example. Feel free to delete or edit the boards and [create your own boards](https://tu2-atmanand.github.io/task-board-docs/docs/How_To/HowToCreateNewBoard/) from the [Board configure modal](https://tu2-atmanand.github.io/task-board-docs/docs/How_To/HowToUseBoardSettings/).
+**Step 4 :** There are already three predefined board for your convenience as an example. Feel free to delete or edit the boards and [create your own boards](https://tu2-atmanand.github.io/task-board-docs/docs/5_How_To/4_HowToCreateNewBoard/) from the [Board configure modal](https://tu2-atmanand.github.io/task-board-docs/docs/5_How_To/6_HowToUseBoardSettings/).
 
 Enjoy !
 
@@ -131,11 +131,11 @@ This advanced and dynamic filters will help you to use boards as separate projec
 
 You can contribute to this project by :
 
-**1. Requesting a new feature, suggesting an improvement or reporting a Bug :** [How to create a new request](https://tu2-atmanand.github.io/task-board-docs/docs/Advanced/HowToCreateRequest).
+**1. Requesting a new feature, suggesting an improvement or reporting a Bug :** [How to create a new request](https://tu2-atmanand.github.io/task-board-docs/docs/10_Advanced/2_HowToCreateRequest/).
 
-**2. Improving the translated languages or add a new language :** [How to Contribute for Language Translation](https://tu2-atmanand.github.io/task-board-docs/docs/Advanced/Contribution_For_Languages).
+**2. Improving the translated languages or add a new language :** [How to Contribute for Language Translation](https://tu2-atmanand.github.io/task-board-docs/docs/10_Advanced/3_How_To_Contribute/2_HowToContributeToTranslations/).
 
-**3. Contribute to the Development of the plugin Code :** : [How to join the plugin development](https://tu2-atmanand.github.io/task-board-docs/docs/Advanced/HowToJoinDevelopment).
+**3. Contribute to the Development of the plugin Code :** : [How to join the plugin development](https://tu2-atmanand.github.io/task-board-docs/docs/10_Advanced/3_How_To_Contribute/4_HowToJoinDevelopment/).
 
 
 ## Motivation for the Project


### PR DESCRIPTION
I was about to install Task Board and noticed that some the links were broken.
It seems the documentation recently had a restructure.

So I updated the most obvious links in the README.