### PR TITLE
Security: Prototype pollution risk in custom EventEmitter event registry

### DIFF
--- a/src/services/EventEmitter.ts
+++ b/src/services/EventEmitter.ts
@@ -1,10 +1,14 @@
 // /src/services/ EventEmitter.ts
 
 class EventEmitter {
-	private events: { [key: string]: Function[] } = {};
+	private events: { [key: string]: Function[] } = Object.create(null);
+	private readonly blockedEvents = new Set(['__proto__', 'constructor', 'prototype']);
 
 	// Add an event listener
 	on(event: string, listener: Function) {
+		if (this.blockedEvents.has(event)) {
+			return;
+		}
 		if (!this.events[event]) {
 			this.events[event] = [];
 		}
@@ -13,6 +17,9 @@ class EventEmitter {
 
 	// Emit an event, calling all listeners
 	emit(event: string, data?: any) {
+		if (this.blockedEvents.has(event)) {
+			return;
+		}
 		if (this.events[event]) {
 			this.events[event].forEach((listener) => listener(data));
 		}
@@ -20,6 +27,9 @@ class EventEmitter {
 
 	// Remove an event listener
 	off(event: string, listener: Function) {
+		if (this.blockedEvents.has(event)) {
+			return;
+		}
 		if (this.events[event]) {
 			this.events[event] = this.events[event].filter(
 				(registeredListener) => registeredListener !== listener


### PR DESCRIPTION
## Summary

Security: Prototype pollution risk in custom EventEmitter event registry

## Problem

**Severity**: `Medium` | **File**: `src/services/EventEmitter.ts:L4`

The event registry uses a plain object (`{ [key: string]: Function[] }`) with attacker-controllable string keys. If an untrusted caller passes special keys such as `__proto__`, `constructor`, or `prototype`, it can mutate object prototype behavior and cause unpredictable runtime effects. While exploitation depends on untrusted access to `on()/emit()/off()`, this is a known unsafe pattern for key-value stores.

## Solution

Replace the plain object with `Map<string, Function[]>` or initialize as `Object.create(null)` and reject reserved keys (`__proto__`, `constructor`, `prototype`). Also strongly type listener signatures to reduce misuse.

## Changes

- `src/services/EventEmitter.ts` (modified)