### PR TITLE
fix : board/column filter and its path autocomplete open in the main window, not the board's popout | #838

### DIFF
--- a/src/components/KanbanView/LazyColumn.tsx
+++ b/src/components/KanbanView/LazyColumn.tsx
@@ -256,6 +256,8 @@ const LazyColumn: React.FC<LazyColumnProps> = ({
 	 * @param {MouseEvent | React.MouseEvent} event - The event that triggered the menu
 	 */
 	function openColumnMenu(event: MouseEvent | React.MouseEvent) {
+		// captured now: event.currentTarget is null inside the async menu-item handler below
+		const boardWin = (event.currentTarget as HTMLElement | null)?.win ?? window;
 		const columnMenu = new Menu();
 
 		columnMenu.addItem((item) => {
@@ -317,8 +319,9 @@ const LazyColumn: React.FC<LazyColumnProps> = ({
 					// );
 					const columnIndex = columnData.index - 1;
 
-					if (Platform.isMobile || Platform.isMacOS) {
-						// If its a mobile platform, then we will open a modal instead of popover.
+					if (Platform.isMobile || Platform.isMacOS || boardWin !== plugin.app.workspace.containerEl.win) {
+						// On mobile/macOS, or when the board is in a popout window, open a modal instead of the popover
+						// (the popover and its path autocomplete render in the main window, not the popout).
 						const filterModal = new ViewTaskFilterModal(
 							plugin, true, undefined, boardIndex, columnData.name, columnData.filters
 						);

--- a/src/components/TaskBoardViewContent.tsx
+++ b/src/components/TaskBoardViewContent.tsx
@@ -290,8 +290,9 @@ const TaskBoardViewContent: React.FC<{ app: App; plugin: TaskBoard; boardConfigs
 	function handleFilterButtonClick(event: React.MouseEvent<HTMLButtonElement>) {
 		try {
 			const currentBoardConfig = boards[activeBoardIndex];
-			if (Platform.isMobile || Platform.isMacOS) {
-				// If its a mobile platform, then we will open a modal instead of popover.
+			if (Platform.isMobile || Platform.isMacOS || event.currentTarget.win !== plugin.app.workspace.containerEl.win) {
+				// On mobile/macOS, or when the board is in a popout window, open a modal instead of the popover
+				// (the popover and its path autocomplete render in the main window, not the popout).
 				const filterModal = new ViewTaskFilterModal(
 					plugin, false, undefined, activeBoardIndex, currentBoardConfig.name
 				);


### PR DESCRIPTION
## Summary

Fixes #838. When the board is open in a **popout window**, opening a filter — the board's **Apply advanced board filters** (funnel button) or a column's **Configure column filtering** (Path Filtered) — showed the filter, and its path autocomplete, in the **main** Obsidian window instead of the popout. This routes the filter to the built-in modal when the board is in a popout.

## Root cause

On desktop the filter is a custom popover (`ViewTaskFilterPopover`); mobile/macOS already use a modal (`ViewTaskFilterModal`). The popover anchors its window to the main workspace container (`app.workspace.containerEl.win`), and its path autocomplete (`AbstractInputSuggest`) appends its `.suggestion-container` to the **main window's** `body`. Obsidian exposes no public hook to target another window for either, so with the board in a popout the popover opened in the main window (and, for column filters, was mis-positioned via a global `document.querySelector`), and the autocomplete rendered in the main window rather than next to the input.

## Fix

When the board is in a popout window (`activeWindow !== app.workspace.containerEl.win`), open the built-in `ViewTaskFilterModal` — the same path already used on mobile/macOS — instead of the popover. The modal is popout-aware and its autocomplete renders in the correct window. In the main window the popover is kept, unchanged.

The change only adds the popout condition to the existing branch; the mobile/macOS path (already a modal) is untouched.

Changed:
- `src/components/TaskBoardViewContent.tsx` — board filter (`handleFilterButtonClick`)
- `src/components/KanbanView/LazyColumn.tsx` — column filter

## Known behavior (not bugs)

- In a popout the filter appears as a **centered modal**, not a popover anchored under the button — this is inherent to Obsidian modals, and identical to the existing mobile/macOS experience.
- The path autocomplete opens on input focus and may open **above** the field, per Obsidian's default suggestion positioning.
- Main-window behavior is unchanged (still a popover).

## Testing

- **Main window (control):** board and column filters open as before; path autocomplete works.
- **Popout window:** both filters now open **in the popout**; path autocomplete (File path / Folder path) shows and is usable.

## Before / after

**Before** — filter opens in the main window: 

https://github.com/user-attachments/assets/f2275bef-92c9-4a86-a1d5-12536e626261

**After** — filter opens in the board's popout: 

https://github.com/user-attachments/assets/a1b5929d-9d04-4d72-9eed-3c7c54d3677e

