### PR TITLE
Fix connection visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4192,7 +4192,7 @@ ReactFlow necessary CSS from its bundle
 }
 
 .react-flow__edge-path {
-	stroke: rgb(var(--canvas-color));
+	stroke: var(--text-muted);
 	/* stroke-width: calc(var(--xy-connectionline-stroke-width, var(--xy-connectionline-stroke-width-default)) / var(--task-board-map-zoom, 1)); */
 	stroke-width: calc(1.5px * var(--task-board-map-zoom));
 	fill: none;
@@ -4200,7 +4200,7 @@ ReactFlow necessary CSS from its bundle
 }
 
 .react-flow__connection-path {
-	stroke: rgb(var(--canvas-color));
+	stroke: var(--text-muted);
 	/* stroke-width: calc(var(--xy-connectionline-stroke-width, var(--xy-connectionline-stroke-width-default)) / var(--task-board-map-zoom, 1)); */
 	stroke-width: calc(1.5px * var(--task-board-map-zoom));
 	fill: none;


### PR DESCRIPTION
## Summary
Fixes #850 - invisible task connections in Map View. Connections were only visible when hovering over them.

## Root cause
`.react-flow__edge-path` and `.react-flow__connection-path` in [styles.css](styles.css) used `stroke: rgb(var(--canvas-color))`, but `--canvas-color` is not defined anywhere in the codebase. An unresolved `var()` invalidates the whole `stroke` declaration, so it fell back to the SVG default of `none` (invisible). The `:hover` rule explicitly set `stroke: var(--text-normal)`, which is why hovering revealed the connection.

## Fix
Replaced `rgb(var(--canvas-color))` with the existing Obsidian theme variable `var(--text-muted)` so edges render visibly by default.